### PR TITLE
remove package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
 14.17.0
-package-lock = false


### PR DESCRIPTION
### Summary
We can remove the `package-lock.json` by putting `package-lock=false` in the `.npmrc` file as apposed to the `.nvmrc` file which is where I put it because I know what I am doing.