### PR TITLE
Fix DB Con, Docker Compose, & Dev Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .vscode
 node_modules
+package-lock.json
+#it keeps coming back

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,2 +1,1 @@
 14.17.0
-package-lock = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN npm install
 
 COPY . .
 
-ENV PORT=8080
-
-EXPOSE 8080
+EXPOSE 3000
 
 CMD [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -9,38 +9,37 @@ A meeting app for professionals.
 - [Getting started with docker](https://www.youtube.com/watch?v=gAkwW2tuIqE&t=121s)
 - [Express.js Apis](https://www.youtube.com/watch?v=-MTSQjw5DrM)
 
-### Api Server Container
+### Getting Started
 
-Build the docker image from the current directory (base image from [here](https://hub.docker.com/_/node))
+### Dockerized
 
-```bash
-docker build -t agenda/api:1.0 .
+With the use of docker compose, you can now use the following to setup agenda
+as a docker swarm.
+
+```shell
+docker-compose build
 ```
 
-_In a seperate terminal_ run the container just built with
+To build the mongo and api containers.
 
-```
-docker container run -p 5000:8080 --name agendapi agenda/api:1.0
-```
-
-In the terminal you should see `Agenda api listening on port 8080`. Logs from the api will appear there. This is the standard port for http. In the above command we mapped port 8080 on the container to the host system's port 5000. Thus, you can access the api through `http://localhost:5000` in the browser.
-
-### MongoDb Container
-
-Pull the mongodb image from dockerhub with (base image found [here](https://hub.docker.com/_/mongo))
-
-```
-docker image pull mongo
+```shell
+docker-compose up
 ```
 
-Run the run the prebuilt mongodb image with
+To run the two containers. The mongodb container will be available through
+`port 27017` and the api will be running on port 3000. (We will need to change
+this for production).
+
+If you want to run
+
+### Local API
+
+For quicker dev we can just `nodemon` to quick restart the api when changes
+are saved to `.js` files (after installing nodemon with `npm i -g nodemon`) with
+the following:
 
 ```
-docker container run -p 27017:27017 --name agendadb mongo
+LOCAL=true nodemon lib/index.js
 ```
 
-Since mongodb listens by default on 27017 and that is the standard port for mongo we map it to our machines port 27017. You should get an error message `It looks like you are trying to access MongoDB over HTTP on the native driver port.` if you go to `http://localhost:27017` in the browser.
-
-# Service Architecture
-![image](https://user-images.githubusercontent.com/54583311/119286538-d8030d80-bc01-11eb-8ff5-352c680c0ac6.png)
-
+Then start mongo in docker desktop (this will not need to be restarted).

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: "3.7"
+
+services:
+  mongodb:
+    image: mongo:latest
+    container_name: mongo
+    volumes:
+      - mongodb-data:/data/db
+    ports:
+      - 27017:27017
+
+  agendaapi:
+    build: ./
+    ports:
+      - 3000:3000
+    depends_on:
+      - mongodb
+
+volumes:
+  mongodb-data:

--- a/lib/controllers/user.js
+++ b/lib/controllers/user.js
@@ -1,0 +1,15 @@
+const User = require("../models/user");
+
+module.exports = {
+  create: (req, res) => {
+    const { firstName, lastName, email } = req.body;
+
+    try {
+      User.create({ firstName, lastName, email });
+      res.sendStatus(200);
+    } catch (err) {
+      res.status(500).send("Something went wrong!");
+      console.error("This be the err: ", err);
+    }
+  },
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,29 @@
-const app = require("express")();
+const express = require("express");
+const app = express();
+const user = require("./routes/user");
+const mongoose = require("mongoose");
 
-app.get("/", (req, res) => {
-  res.json({
-    message: "Hello from agenda",
-  });
+mongoose.connect("mongodb://host.docker.internal:27017/agenda", {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
 });
 
-const port = process.env.PORT || 8080;
+const db = mongoose.connection;
+
+db.on("error", console.error.bind(console, "connection error"));
+
+db.on("open", () => {
+  console.log("connected");
+});
+
+mongoose.set("useCreateIndex", true);
+
+//body parser is deprecated so in Express 4.16+ ( we have 4.17.1) we use these two lines for body parsing
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+app.use("/user", user);
+
+const port = process.env.PORT || 3000;
 
 app.listen(port, () => console.log("Agenda api listening on " + port));

--- a/lib/models/meeting.js
+++ b/lib/models/meeting.js
@@ -4,10 +4,10 @@ const meetingSchema = new mongoose.Schema(
   {
     owner: { type: Schema.Types.ObjectId, ref: "User" },
     participants: [{ type: Schema.Types.ObjectId, ref: "Participant" }],
-    date: String
+    date: String,
   },
   {
-    timestamps: true
+    timestamps: true,
   }
 );
 

--- a/lib/routes/user.js
+++ b/lib/routes/user.js
@@ -1,0 +1,6 @@
+const router = require("express").Router();
+const userResource = require("../controllers/user");
+
+router.post("/create", userResource.create);
+
+module.exports = router;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "start": "node lib/index.js",
+    "dev": "nodemon lib/index.js",
     "test": "test.js"
   },
   "repository": {
@@ -24,7 +25,10 @@
   },
   "homepage": "https://github.com/SocexSolutions/agenda#readme",
   "dependencies": {
-    "mongoose": "^5.12.10",
-    "express": "^4.17.1"
+    "mongoose": "5.12.10",
+    "express": "4.17.1"
+  },
+  "devDependencies": {
+    "nodemon": "2.0.7"
   }
 }


### PR DESCRIPTION
### Summary
Mr Olignaaa was indeed correct about needing to `require("express")` separately so all of that stuff is in this PR (just going to leave the commits in to show who done it). I also added a `docker-compose.yaml` file which allows us to build all the containers (including the frontend when it is added in) with `docker-compose build` and run them with `docker-compose up`. I also added a new script that allows us to run it locally with `npm run dev` without rebuilding the container repeatedly. Since `controllers` seems to be the *standard* (from back when PHP was cool) we will use that instead of `resources` 😢. 

### Changes
- Add `nodemon` for quicker dev (added to `dev-dependencies`) and corresponding `dev` script
- Add `require("express")` separately in `index.js` and `user.js` routes
- Add docker-compose.yaml
- Swap docker connect `localhost` to internal docker virtual network
- Fixed `express.urelencoded()` error ( `extended: true`) allows for query params if we need them